### PR TITLE
Fix ambiguous AA lookup in FilesystemState.hasDevice

### DIFF
--- a/source/btrfs/fs.d
+++ b/source/btrfs/fs.d
@@ -389,9 +389,12 @@ public:
 
     bool hasDevice(const ubyte[UUID_SIZE] deviceUUID) const
     {
-        if (deviceUUID in this.devices)
+        foreach (uuid, _; this.devices)
         {
-            return true;
+            if (uuid == deviceUUID)
+            {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
This change fixes an ldc2 compile error caused by ambiguous associative-array lookup overload resolution with shared/const qualifiers in fs.d.

Reworked hasDevice in fs.d to avoid the ambiguous key in aa lookup path.
Implemented a qualifier-safe key existence check by iterating AA keys directly and comparing UUID values.
Kept behavior unchanged: hasDevice still returns true when the device UUID exists, otherwise false.